### PR TITLE
Fix error on pop with opts

### DIFF
--- a/lua/stackmap/init.lua
+++ b/lua/stackmap/init.lua
@@ -76,7 +76,7 @@ M.pop = function(name, mode)
 
 			vim.keymap.set(mode, lhs, rhs, opts)
 		else
-			vim.keymap.del(mode, map[1])
+			vim.keymap.del(mode, map[1], map[3])
 		end
 	end
 end


### PR DESCRIPTION
Hi! Thanks for the awesome plugin! I'm trying my hand on making a dedicated DEBUG mode and it proves to be hugely useful! I love that it's so small.

I did a little fix that resolved my issue related to popping when the keymap has some opts in it. So for example, if I were to pop such a stack:
```
stackmap.push("debug_mode", "n", {
{ "c", function() require("dap").continue() end,{buffer=bufnr, silent=true, nowait = true}, desc = "Continue" },
```
with the {buffer=bufnr, silent=true, nowait = true} I was getting an error:
```
E5108: Error executing lua: vim/keymap.lua:0: E31: No such mapping
stack traceback:
        [C]: in function 'nvim_del_keymap'
        vim/keymap.lua: in function 'del'
        ...ocal/share/nvim/lazy/stackmap.nvim/lua/stackmap/init.lua:74: in function 'pop'
```

